### PR TITLE
Fix z-index and positioning of info box when hovered

### DIFF
--- a/Library Move Extra Info/shared.css
+++ b/Library Move Extra Info/shared.css
@@ -1,4 +1,5 @@
-.BasicUI .appportrait_LibraryItemBox_WYgDg:focus~.appportrait_LibraryItemBoxSubscript_1LJqx
+.BasicUI .appportrait_LibraryItemBox_WYgDg.gpfocus~.appportrait_LibraryItemBoxSubscript_1LJqx,
+.BasicUI .appportrait_LibraryItemBox_WYgDg:hover~.appportrait_LibraryItemBoxSubscript_1LJqx
 {
     z-index: 13;
 }
@@ -13,7 +14,8 @@
     padding-right: 10px !important;
 }
 
-.appportrait_LibraryItemBox_WYgDg:focus~.appportrait_LibraryItemBoxSubscript_1LJqx {
+.appportrait_LibraryItemBox_WYgDg.gpfocus~.appportrait_LibraryItemBoxSubscript_1LJqx,
+.appportrait_LibraryItemBox_WYgDg:hover~.appportrait_LibraryItemBoxSubscript_1LJqx {
     transform: translateY(-1px) translateZ(15px);
     margin-left: 2px;
 }

--- a/Library Move Extra Info/shared.css
+++ b/Library Move Extra Info/shared.css
@@ -39,3 +39,9 @@
 .appportrait_LibraryItemBoxSubscript_1LJqx.appportrait_MCRed_3lWVD {
     line-height: 16px !important;
 }
+
+.appportrait_LibraryItemBoxSubscript_1LJqx.appportrait_MCGreen_1KR40,
+.appportrait_LibraryItemBoxSubscript_1LJqx.appportrait_MCOrange_1H3NR {
+    color: #0e141b;
+    text-shadow: none;
+}


### PR DESCRIPTION
Info boxes were staying behind the capsules when hovered with mouse, I used the same css selectors used by the Steam UI to fix it. Also noticed that the white text on the green and orange info boxes for metacritic scores were hard to read, so I made their text darker.